### PR TITLE
Script to release binary to github

### DIFF
--- a/release-github-binaries.sh
+++ b/release-github-binaries.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+
+set -u -e -o pipefail
+
+TAG="${1:-}"
+
+if [[ -z "$TAG" ]] ; then
+  echo "ERROR: No release tag specified" >&2
+  exit 1
+fi
+
+if [[ -z "$GITHUB_TOKEN" ]] ; then
+  echo "ERROR: Env variable GITHUB_TOKEN not set. Get one in GH account Settings -> Developer settings -> Personal access tokens (use 'public_repo' scope)" >&2
+  exit 1
+fi
+
+if [[ ! -x "custom-prometheus-exporter" ]] ; then
+  echo "ERROR: Missing binary, please build it" >&2
+  exit 1
+fi
+
+echo "Getting ghr"
+
+go get github.com/tcnksm/ghr
+
+echo "Creating archive"
+rm -rf dist/
+mkdir dist
+tar -czf "dist/custom-prometheus-exporter-$TAG-amd64.tar.gz" custom-prometheus-exporter LICENSE README.md
+sha256sum dist/*.tar.gz > dist/sha256sums.txt
+
+echo "Upload to Github"
+
+ghr -parallel 1 -u marckhouzam -r custom-prometheus-exporter --replace "$TAG" dist/
+
+echo "Done"


### PR DESCRIPTION
Based on https://github.com/oliver006/redis_exporter/blob/master/release-github-binaries.sh

Fixes #2 

I assume it is obvious for any golang person, but I also had to add ght to my path like this before running the script:

```
export PATH="$PATH:$HOME/go/bin/"
```

And to get `GITHUB_TOKEN` environmental value, you need to create it in GH account Settings -> Developer settings -> Personal access tokens (use 'public_repo' scope). There are other ways how to configure this secret, but now script enforces env variable. See https://github.com/tcnksm/ghr#github-api-token

Also script assumes you are on x86_64 architecture on Linux. I did not wanted to start with cross-arch builds as that is completely new land to me.